### PR TITLE
Add version flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Instructions for Codex Agents
+
+- Whenever you modify code in this repository, you **must** bump the version number
+  in `setup.py` and in `lets_cli/__init__.py`.
+- Keep both version numbers identical.
+- Document the changes in `CHANGELOG.md` under a new heading if appropriate.
+- After making changes, run any available tests or checks before committing.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.0.3] - 2025-07-13
+
+- Added `--version` option to display the installed version
+
 ## [0.0.1] - 2024-06-16
 
 - created

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ source venv/bin/activate
 lets show me a list of all docker containers currently running
 ```
 
+## Checking your version
+
+```bash
+lets --version
+```
+
 ## pid its running on
 
 ```

--- a/lets_cli/__init__.py
+++ b/lets_cli/__init__.py
@@ -1,0 +1,5 @@
+"""Core package for lets_cli."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.0.3"

--- a/lets_cli/main.py
+++ b/lets_cli/main.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+from lets_cli import __version__
 from lets_cli.nlp import interpret_command
 from lets_cli.spinner import Spinner
 import requests
@@ -8,6 +9,9 @@ import requests
 debug_mode = False  # Set to False to disable debug output
 
 def main() -> None:
+    if len(sys.argv) == 2 and sys.argv[1] == "--version":
+        print(__version__)
+        return
     if len(sys.argv) < 2:
         print("Usage: lets <natural language command>")
         sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def parse_requirements(filename):
 
 setup(
     name='lets_cli',
-    version='0.0.2',
+    version='0.0.3',
     packages=find_packages(),
     install_requires=parse_requirements('requirements.txt'),
     entry_points={


### PR DESCRIPTION
## Summary
- expose package version in lets_cli package
- show version with `lets --version`
- document new flag in README
- document release in CHANGELOG
- add AGENTS instructions for future contributors

## Testing
- `python3 -m compileall -q lets_cli`
- `pip install -e .` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6873e2a07014832e8b2e9b7e0484c43e